### PR TITLE
Revert "Support for Nutch 1.16."

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ This connector is an implementation of the
 
    b. Checkout the desired version of the connector and build the ZIP file:
       ```
-      git checkout master # TODO(wiarlawd): tags/v1-0.0.5
+      git checkout tags/v1-0.0.5
       mvn package
       ```
       (To skip the tests when building the connector, use `mvn package -DskipTests`)
 
-2. Download [Apache Nutch 1.16](http://archive.apache.org/dist/nutch/1.16/) and follow the Apache
+2. Download [Apache Nutch 1.15](http://archive.apache.org/dist/nutch/1.15/) and follow the Apache
    Nutch instructions (https://wiki.apache.org/nutch/NutchTutorial) to install.
 
 3. Extract `target/google-cloudsearch-apache-nutch-indexer-plugin-v1.0.0.5.zip` built from step 2 to
    a folder. Copy `plugins/indexer-google-cloud-search` folder to the Apache Nutch install plugins
-   folder (`apache-nutch-1.16/plugins`).
+   folder (`apache-nutch-1.15/plugins`).
 
 For further information on configuration and deployment of this indexer plugin, see
 [Deploy an Apache Nutch Indexer

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-mapred</artifactId>
+        <version>0.22.0</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.enterprise.cloudsearch</groupId>
@@ -294,13 +306,7 @@
     <dependency>
       <groupId>org.apache.nutch</groupId>
       <artifactId>nutch</artifactId>
-      <version>1.16</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>2.9.2</version>
+      <version>1.15</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/plugin/indexer-google-cloudsearch/src/java/org/apache/nutch/indexwriter/gcs/GoogleCloudSearchIndexWriter.java
+++ b/src/plugin/indexer-google-cloudsearch/src/java/org/apache/nutch/indexwriter/gcs/GoogleCloudSearchIndexWriter.java
@@ -42,12 +42,9 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.util.AbstractMap;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
@@ -63,10 +60,7 @@ public class GoogleCloudSearchIndexWriter implements IndexWriter {
   static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String CONFIG_KEY_CONFIG_FILE = "gcs.config.file";
-  public static final String CONFIG_KEY_CONFIG_FILE_DESC =
-      "Path to Google Cloud Search configuration file";
   public static final String CONFIG_KEY_UPLOAD_FORMAT = "gcs.uploadFormat";
-  public static final String CONFIG_KEY_UPLOAD_FORMAT_DESC = "Upload Format";
   public static final String FIELD_ID = "id";
   public static final String FIELD_URL = "url";
   public static final String FIELD_RAW_CONTENT = "binaryContent";
@@ -236,13 +230,8 @@ public class GoogleCloudSearchIndexWriter implements IndexWriter {
   }
 
   @Override
-  public Map<String, Entry<String, Object>> describe() {
-    Map<String, Map.Entry<String, Object>> properties = new LinkedHashMap<>();
-    properties.put(CONFIG_KEY_CONFIG_FILE,
-        new AbstractMap.SimpleEntry<>(CONFIG_KEY_CONFIG_FILE_DESC, this.configPath));
-    properties.put(CONFIG_KEY_UPLOAD_FORMAT,
-        new AbstractMap.SimpleEntry<>(CONFIG_KEY_UPLOAD_FORMAT_DESC, this.uploadFormat));
-    return properties;
+  public String describe() {
+    return "Google Cloud Search Indexer";
   }
 
   @Override

--- a/src/plugin/indexer-google-cloudsearch/src/test/org/apache/nutch/indexwriter/gcs/TestGoogleCloudSearchIndexWriter.java
+++ b/src/plugin/indexer-google-cloudsearch/src/test/org/apache/nutch/indexwriter/gcs/TestGoogleCloudSearchIndexWriter.java
@@ -41,16 +41,12 @@ import com.google.enterprise.cloudsearch.sdk.indexing.IndexingService.RequestMod
 import com.google.enterprise.cloudsearch.sdk.indexing.StructuredData.ResetStructuredDataRule;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Properties;
 import org.apache.nutch.indexer.IndexWriterParams;
 import org.apache.nutch.indexer.NutchDocument;
 import org.apache.nutch.indexwriter.gcs.GoogleCloudSearchIndexWriter.Helper;
-import org.apache.nutch.indexwriter.gcs.GoogleCloudSearchIndexWriter.UploadFormat;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -402,14 +398,7 @@ public class TestGoogleCloudSearchIndexWriter {
 
   @Test
   public void describeShouldReturnPluginName() {
-    Map<String, Map.Entry<String, Object>> properties = new LinkedHashMap<>();
-    properties.put(GoogleCloudSearchIndexWriter.CONFIG_KEY_CONFIG_FILE,
-        new AbstractMap.SimpleEntry<>(GoogleCloudSearchIndexWriter.CONFIG_KEY_CONFIG_FILE_DESC,
-            null));
-    properties.put(GoogleCloudSearchIndexWriter.CONFIG_KEY_UPLOAD_FORMAT,
-        new AbstractMap.SimpleEntry<>(GoogleCloudSearchIndexWriter.CONFIG_KEY_UPLOAD_FORMAT_DESC,
-            UploadFormat.RAW));
-    assertEquals(properties, subject.describe());
+    assertEquals("Google Cloud Search Indexer", subject.describe());
   }
 
   @Test


### PR DESCRIPTION
Reverts google-cloudsearch/apache-nutch-indexer-plugin#7

There are apparently problems with the newer version of Tika in Nutch 1.16. See bug 145240219 for details.